### PR TITLE
Rename difficulty to selection_frequency for question display and filters

### DIFF
--- a/src/app/courses/[courseCode]/question/[questionId]/edit/tabs/question-tab.tsx
+++ b/src/app/courses/[courseCode]/question/[questionId]/edit/tabs/question-tab.tsx
@@ -66,25 +66,52 @@ export default function QuestionTab({
               </p>
             </div>
 
-            {/* Difficulty */}
-            <div className="flex flex-col gap-2">
-              <Label
-                htmlFor="difficulty"
-                className="text-md font-semibold text-foreground"
-              >
-                Difficulty
-              </Label>
-              <Input
-                id="difficulty"
-                className="w-1/4"
-                value={question?.difficulty ?? "0.0000"}
-                disabled
-                readOnly
-              />
-              <p className="text-xs text-muted-foreground">
-                The difficulty of the question as given on question upload.
-              </p>
-            </div>
+            {/* Correct Answer Rate / Difficulty */}
+            {(() => {
+              if (question && question.selection_frequency > 0) {
+                return (
+                  <div className="flex flex-col gap-2">
+                    <Label
+                      htmlFor="selection-frequency"
+                      className="text-md font-semibold text-foreground"
+                    >
+                      Correct Answer Rate
+                    </Label>
+                    <Input
+                      id="selection-frequency"
+                      className="w-1/4"
+                      value={question.selection_frequency}
+                      disabled
+                      readOnly
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      The percentage of students who answered this question correctly.
+                    </p>
+                  </div>
+                );
+              } else {
+                return (
+                  <div className="flex flex-col gap-2">
+                    <Label
+                      htmlFor="difficulty"
+                      className="text-md font-semibold text-foreground"
+                    >
+                      Difficulty
+                    </Label>
+                    <Input
+                      id="difficulty"
+                      className="w-1/4"
+                      value={question?.difficulty ?? "0.0000"}
+                      disabled
+                      readOnly
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      The difficulty of the question as given on question upload.
+                    </p>
+                  </div>
+                );
+              }
+            })()}
 
             {/* Unit */}
             <div className="flex flex-col gap-2">

--- a/src/components/macfast/questions-filter.tsx
+++ b/src/components/macfast/questions-filter.tsx
@@ -33,8 +33,8 @@ export function QuestionsFilter({
 }: QuestionsFilterProps) {
   const [open, setOpen] = useState(false);
   const [sliderValue, setSliderValue] = useState([
-    filters.min_difficulty ?? 0,
-    filters.max_difficulty ?? 1,
+    filters.min_selection_frequency ?? 0,
+    filters.max_selection_frequency ?? 1,
   ]);
 
   const debouncedFilterChange = useMemo(
@@ -44,8 +44,8 @@ export function QuestionsFilter({
         const maxVal = value[1] < 1 ? value[1] : undefined;
         onFilterChange({
           ...filters,
-          min_difficulty: minVal,
-          max_difficulty: maxVal,
+          min_selection_frequency: minVal,
+          max_selection_frequency: maxVal,
         });
       }, 300),
     [filters, onFilterChange],
@@ -118,7 +118,7 @@ export function QuestionsFilter({
           <div className="space-y-3">
             <div className="flex justify-between items-center">
               <Label className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                Difficulty
+                Correct Answer Rate
               </Label>
               <span className="text-sm text-muted-foreground">
                 {sliderValue[0].toFixed(2)} - {sliderValue[1].toFixed(2)}

--- a/src/components/macfast/questions-item/questions-item.tsx
+++ b/src/components/macfast/questions-item/questions-item.tsx
@@ -56,16 +56,27 @@ function QuestionItem({
               </Badge>
             )}
 
-            <Badge
-              variant="secondary"
-              className="text-muted-foreground whitespace-nowrap"
-            >
-              <Star
-                fill="currentColor"
-                className="inline-block mr-1 h-3 w-3 text-primary-hover"
-              />
-              Difficulty {question.difficulty}
-            </Badge>
+            {(() => {
+              let badgeText: string;
+              if (question.selection_frequency > 0) {
+                badgeText = `Correct Answer Rate ${question.selection_frequency}`;
+              } else {
+                badgeText = `Difficulty ${question.difficulty}`;
+              }
+
+              return (
+                <Badge
+                  variant="secondary"
+                  className="text-muted-foreground whitespace-nowrap"
+                >
+                  <Star
+                    fill="currentColor"
+                    className="inline-block mr-1 h-3 w-3 text-primary-hover"
+                  />
+                  {badgeText}
+                </Badge>
+              );
+            })()}
 
             {question.is_flagged && (
               <Badge variant="destructive">

--- a/src/hooks/useCourseQuestions.ts
+++ b/src/hooks/useCourseQuestions.ts
@@ -55,12 +55,12 @@ export function useCourseQuestions({
       queryParams.append("is_flagged", filters.is_flagged.toString());
     }
 
-    if (filters.min_difficulty !== undefined) {
-      queryParams.append("difficulty__gte", filters.min_difficulty.toString());
+    if (filters.min_selection_frequency !== undefined) {
+      queryParams.append("selection_frequency__gte", filters.min_selection_frequency.toString());
     }
 
-    if (filters.max_difficulty !== undefined) {
-      queryParams.append("difficulty__lte", filters.max_difficulty.toString());
+    if (filters.max_selection_frequency !== undefined) {
+      queryParams.append("selection_frequency__lte", filters.max_selection_frequency.toString());
     }
 
     if (filters.subtopic_name) {

--- a/src/types/Question.ts
+++ b/src/types/Question.ts
@@ -3,6 +3,7 @@ interface Question {
   serial_number: string;
   content: string;
   difficulty: number;
+  selection_frequency: number;
   is_flagged: boolean;
   is_active: boolean;
   is_verified: boolean;

--- a/src/types/QuestionFilters.ts
+++ b/src/types/QuestionFilters.ts
@@ -1,7 +1,7 @@
 interface QuestionFilters {
   is_verified?: boolean | null;
   is_flagged?: boolean | null;
-  min_difficulty?: number;
-  max_difficulty?: number;
+  min_selection_frequency?: number;
+  max_selection_frequency?: number;
   subtopic_name?: string | null;
 }


### PR DESCRIPTION
Issue: https://github.com/McMaster-FAST/frontend/issues/63

- Rename "Difficulty" to "Correct Answer Rate" using `selection_frequency` field
- Fall back to "Difficulty" when `selection_frequency` is not available