### PR TITLE
feat: integrate gamification display in question test page

### DIFF
--- a/src/app/courses/[courseCode]/[unitName]/[subtopicName]/test/page.tsx
+++ b/src/app/courses/[courseCode]/[unitName]/[subtopicName]/test/page.tsx
@@ -31,6 +31,8 @@ import SaveForLater from "@/components/macfast/save-for-later";
 import { QuestionPage } from "@/components/macfast/question-page";
 import { MacFastHeader } from "@/components/macfast/macfast-header";
 import { SafeHtml } from "@/components/macfast/safe-html";
+import { GamificationHUD } from "@/components/macfast/gamification-hud";
+import { Gamification } from "@/types/Gamification";
 import QuestionOption from "@/components/macfast/question-option/question-option";
 
 interface QuestionTestPageProps {
@@ -95,6 +97,7 @@ function QuestionTestPage({ params: paramsPromise }: QuestionTestPageProps) {
   const [isQuestionLoading, setIsQuestionLoading] = useState<boolean>(true);
   const [actions, setActions] = useState<ActionInfo[]>([]);
   const [notes, setNotes] = useState<JSX.Element[]>([]);
+  const [gamification, setGamification] = useState<Gamification | null>(null);
 
   const courseErrorMessage = useMemo(() => {
     if (courseLoading || !courseLoadError) return null;
@@ -203,12 +206,12 @@ function QuestionTestPage({ params: paramsPromise }: QuestionTestPageProps) {
       question: TestQuestion;
       continue_actions: ContinueAction[];
       suggested_actions: SuggestedAction[];
+      gamification: Gamification | null;
     }>,
     resolvedSubtopicId: string,
   ) => {
     questionPromise
-      .then(({ question, continue_actions, suggested_actions }) => {
-        console.log(suggested_actions);
+      .then(({ question, continue_actions, suggested_actions, gamification }) => {
         setQuestion(question);
         setActions(
           generateActionsForContinueActions(
@@ -217,6 +220,7 @@ function QuestionTestPage({ params: paramsPromise }: QuestionTestPageProps) {
           ),
         );
         setNotes(generateNoteFromSuggestedActions(suggested_actions));
+        if (gamification) setGamification(gamification);
       })
       .catch((err: Error) => {
         setError(err.message);
@@ -248,6 +252,16 @@ function QuestionTestPage({ params: paramsPromise }: QuestionTestPageProps) {
         setSubmitSuccess(true);
         setCorrectOptionId(data.correct_option_id);
         setSolution(data.explanation);
+        // Optimistically update counters we can derive from the answer result
+        const isCorrect = selectedOption === data.correct_option_id;
+        setGamification((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            questions_answered: prev.questions_answered + 1,
+            current_streak: isCorrect ? prev.current_streak + 1 : 0,
+          };
+        });
       })
       .catch((err) => setError(err.message));
   };
@@ -284,11 +298,18 @@ function QuestionTestPage({ params: paramsPromise }: QuestionTestPageProps) {
         <MacFastHeader />
       </QuestionPage.Header>
       <QuestionPage.Title>
-        <h1>{courseCode}</h1>
-        <ChevronsRight />
-        <h1>{unit_name}</h1>
-        <ChevronsRight />
-        <h1>{subtopic_name}</h1>
+        <div className="flex flex-col gap-3 w-full">
+          <div className="flex items-center gap-2 min-w-0">
+            <h1>{courseCode}</h1>
+            <ChevronsRight />
+            <h1>{unit_name}</h1>
+            <ChevronsRight />
+            <h1>{subtopic_name}</h1>
+          </div>
+          {gamification && (
+            <GamificationHUD gamification={gamification} />
+          )}
+        </div>
       </QuestionPage.Title>
       <QuestionPage.Content>
         <TestContinueDialog

--- a/src/components/macfast/gamification-hud.tsx
+++ b/src/components/macfast/gamification-hud.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Gamification, DifficultyLabel } from "@/types/Gamification";
+import {
+  Flame,
+  ShieldCheck,
+  Minus,
+  Zap,
+} from "lucide-react";
+
+interface GamificationHUDProps {
+  gamification: Gamification;
+  className?: string;
+}
+
+const difficultyConfig: Record<
+  DifficultyLabel,
+  { label: string; icon: React.ReactNode; classes: string }
+> = {
+  MUCH_EASIER: {
+    label: "Much Easier",
+    icon: <ShieldCheck className="h-4 w-4" />,
+    classes: "bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-800",
+  },
+  EASIER: {
+    label: "Easier",
+    icon: <ShieldCheck className="h-4 w-4" />,
+    classes: "bg-sky-100 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300 dark:border-sky-800",
+  },
+  ON_TARGET: {
+    label: "On Target",
+    icon: <Minus className="h-4 w-4" />,
+    classes: "bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+  },
+  HARDER: {
+    label: "Harder",
+    icon: <Flame className="h-4 w-4" />,
+    classes: "bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-950/40 dark:text-orange-300 dark:border-orange-800",
+  },
+  MUCH_HARDER: {
+    label: "Much Harder",
+    icon: <Zap className="h-4 w-4" />,
+    classes: "bg-red-100 text-red-700 border-red-200 dark:bg-red-950/40 dark:text-red-300 dark:border-red-800",
+  },
+};
+
+function abilityToPercent(ability: number): number {
+  return Math.round(((ability + 3) / 6) * 100);
+}
+
+function abilityBarColor(ability: number): string {
+  if (ability >= 1) return "bg-green-500";
+  if (ability >= -1) return "bg-amber-400";
+  return "bg-red-500";
+}
+
+function confidenceLabel(variance: number): string {
+  if (variance <= 1) return "High confidence";
+  if (variance <= 3) return "Moderate confidence";
+  return "Still calibrating…";
+}
+
+export function GamificationHUD({ gamification, className }: GamificationHUDProps) {
+  const {
+    user_ability,
+    ability_variance,
+    current_streak,
+    difficulty_label,
+  } = gamification;
+
+  const abilityPct = abilityToPercent(user_ability);
+  const barColor = abilityBarColor(user_ability);
+  const diff = difficulty_label ? difficultyConfig[difficulty_label] : null;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-5 font-normal text-base",
+        className,
+      )}
+    >
+      {/* Streak */}
+      <div
+        title={`Current streak: ${current_streak}`}
+        className={cn(
+          "flex items-center gap-2 px-4 py-2 rounded-full border transition-colors",
+          current_streak >= 3
+            ? "bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-950/40 dark:text-orange-300 dark:border-orange-800"
+            : "bg-muted text-muted-foreground border-border",
+        )}
+      >
+        <Flame
+          className={cn(
+            "h-5 w-5",
+            current_streak >= 3 && "text-orange-500",
+          )}
+        />
+        <span className="font-bold tabular-nums">{current_streak}</span>
+      </div>
+
+      {/* Ability bar */}
+      <div
+        className="flex flex-col gap-1.5 min-w-[200px]"
+        title={`Skill level: ${abilityPct}% — ${confidenceLabel(ability_variance)}`}
+      >
+        <div className="flex justify-between text-sm leading-none text-muted-foreground">
+          <span>Skill</span>
+          <span>{abilityPct}%</span>
+        </div>
+        <div className="relative h-3 rounded-full bg-muted overflow-hidden">
+          <div
+            className={cn("h-full rounded-full transition-all duration-700", barColor)}
+            style={{ width: `${abilityPct}%` }}
+          />
+          {/* Confidence indicator: overlay dims bar when variance is high */}
+          <div
+            className="absolute inset-0 bg-background rounded-full transition-opacity duration-700"
+            style={{
+              opacity: Math.min(ability_variance / 10, 0.55),
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Difficulty badge */}
+      {diff && (
+        <div
+          className={cn(
+            "flex items-center gap-2 px-4 py-2 rounded-full border font-semibold transition-all duration-300",
+            diff.classes,
+          )}
+          title={`This question is ${diff.label} relative to your current level`}
+        >
+          {diff.icon}
+          <span>{diff.label}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/adaptive-test-api.ts
+++ b/src/lib/adaptive-test-api.ts
@@ -4,6 +4,7 @@ import {
   ContinueAction,
   SuggestedAction,
 } from "@/types/actions/ContinueAction";
+import { Gamification } from "@/types/Gamification";
 
 const API_BASE_URL = "/api/core/adaptive-test";
 
@@ -39,13 +40,19 @@ function convertToTestQuestion(data: any): {
   question: TestQuestion;
   continue_actions: ContinueAction[];
   suggested_actions: SuggestedAction[];
+  gamification: Gamification | null;
 } {
   const question_data = data.question;
+  const gamification: Gamification | null = data.gamification ?? null;
+  const continue_actions = convertToContinueActions(data.continue_actions);
+  const suggested_actions = convertToSuggestedActions(data.suggested_actions);
+
   if (!question_data) {
     return {
       question: {} as TestQuestion,
-      continue_actions: convertToContinueActions(data.continue_actions),
-      suggested_actions: convertToSuggestedActions(data.suggested_actions),
+      continue_actions,
+      suggested_actions,
+      gamification,
     };
   }
   const options = question_data.options.map(
@@ -61,8 +68,9 @@ function convertToTestQuestion(data: any): {
       ...question_data,
       options: options,
     } as TestQuestion,
-    continue_actions: convertToContinueActions(data.continue_actions),
-    suggested_actions: convertToSuggestedActions(data.suggested_actions),
+    continue_actions,
+    suggested_actions,
+    gamification,
   };
 }
 

--- a/src/types/Gamification.ts
+++ b/src/types/Gamification.ts
@@ -1,0 +1,16 @@
+export type DifficultyLabel =
+  | "MUCH_EASIER"
+  | "EASIER"
+  | "ON_TARGET"
+  | "HARDER"
+  | "MUCH_HARDER";
+
+export interface Gamification {
+  user_ability: number; // -3.0 to 3.0
+  ability_variance: number; // 0 to 10 (high = uncertain, low = confident)
+  questions_answered: number;
+  current_streak: number;
+  question_difficulty?: number; // -3.0 to 3.0, absent when no question available
+  difficulty_delta?: number;
+  difficulty_label?: DifficultyLabel;
+}


### PR DESCRIPTION
* Added GamificationHUD component to display gamification data.
* Updated state management to include gamification information.
* Modified API response handling to include gamification data.
* Optimistically update gamification counters based on user answers.

Requires https://github.com/McMaster-FAST/backend/pull/92 to be merged first